### PR TITLE
Show paused state on action badge

### DIFF
--- a/background.js
+++ b/background.js
@@ -101,6 +101,12 @@ function cleanURL(url) {
 
 // Update badge text and color
 function updateBadge() {
+  if (!settings.isEnabled) {
+    chrome.action.setBadgeText({ text: '⏸' });
+    chrome.action.setBadgeBackgroundColor({ color: '#F44336' });
+    return;
+  }
+
   if (settings.cleanedCount > 0) {
     chrome.action.setBadgeText({ text: settings.cleanedCount.toString() });
     chrome.action.setBadgeBackgroundColor({ color: '#4CAF50' });
@@ -167,6 +173,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   if (request.action === 'toggle') {
     settings.isEnabled = request.enabled;
     chrome.storage.sync.set({ isEnabled: settings.isEnabled });
+    updateBadge();
     console.log('Clean URL: Toggled', settings.isEnabled);
     sendResponse({ success: true, isEnabled: settings.isEnabled });
 
@@ -193,6 +200,7 @@ chrome.storage.onChanged.addListener((changes, namespace) => {
     if (changes.isEnabled) {
       settings.isEnabled = changes.isEnabled.newValue;
       console.log('Clean URL: Settings synced - isEnabled:', settings.isEnabled);
+      updateBadge();
     }
     if (changes.cleanedCount) {
       settings.cleanedCount = changes.cleanedCount.newValue;

--- a/popup.js
+++ b/popup.js
@@ -10,7 +10,7 @@ function updateUI() {
   document.getElementById('statusText').textContent =
     currentStatus.isEnabled ? '✅ Enabled' : '⏸️ Disabled';
   document.getElementById('statusText').style.color =
-    currentStatus.isEnabled ? '#4CAF50' : '#999';
+    currentStatus.isEnabled ? '#4CAF50' : '#F44336';
 }
 
 // Fetch the current status when the popup opens


### PR DESCRIPTION
## Summary
- show a red pause badge when the extension is disabled
- refresh the badge when toggled or synced across extension contexts
- update popup status text to turn red when paused

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc612ca348328ba1ff6517b9a5998