### PR TITLE
Add per-site exclusions and pause controls

### DIFF
--- a/background.js
+++ b/background.js
@@ -42,16 +42,43 @@ const TRACKING_PARAMS = [
 // Extension state persisted in storage
 let settings = {
   isEnabled: true,
-  cleanedCount: 0
+  cleanedCount: 0,
+  excludedDomains: [],
+  pauseUntil: null
 };
 
+let activeTabId = null;
+let activeTabDomain = null;
+
 // Load settings on startup
-chrome.storage.sync.get(['isEnabled', 'cleanedCount'], (result) => {
+chrome.storage.sync.get(['isEnabled', 'cleanedCount', 'excludedDomains', 'pauseUntil'], (result) => {
   settings.isEnabled = result.isEnabled !== false;
   settings.cleanedCount = result.cleanedCount || 0;
+  settings.excludedDomains = Array.isArray(result.excludedDomains) ? result.excludedDomains : [];
+  settings.pauseUntil = typeof result.pauseUntil === 'number' ? result.pauseUntil : null;
+  ensurePauseFreshness();
+  determineActiveTab();
   updateBadge();
   console.log('Clean URL: Loaded settings', settings);
 });
+
+function determineActiveTab() {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (chrome.runtime.lastError) {
+      console.warn('Clean URL: Unable to query active tab', chrome.runtime.lastError);
+      return;
+    }
+    const [tab] = tabs;
+    if (tab) {
+      activeTabId = tab.id;
+      activeTabDomain = extractHostname(tab.url);
+    } else {
+      activeTabId = null;
+      activeTabDomain = null;
+    }
+    updateBadge();
+  });
+}
 
 // URL cleaning helper
 function cleanURL(url) {
@@ -107,6 +134,18 @@ function updateBadge() {
     return;
   }
 
+  if (isTemporarilyPaused()) {
+    chrome.action.setBadgeText({ text: '⏳' });
+    chrome.action.setBadgeBackgroundColor({ color: '#9E9E9E' });
+    return;
+  }
+
+  if (activeTabDomain && settings.excludedDomains.includes(activeTabDomain)) {
+    chrome.action.setBadgeText({ text: '🚫' });
+    chrome.action.setBadgeBackgroundColor({ color: '#9E9E9E' });
+    return;
+  }
+
   if (settings.cleanedCount > 0) {
     chrome.action.setBadgeText({ text: settings.cleanedCount.toString() });
     chrome.action.setBadgeBackgroundColor({ color: '#4CAF50' });
@@ -119,15 +158,53 @@ function updateBadge() {
 function incrementCount() {
   settings.cleanedCount++;
   chrome.storage.sync.set({ cleanedCount: settings.cleanedCount });
-  updateBadge();
+  notifyStatusChanged();
+}
 
-  // Notify the popup to refresh (if it is open)
+function notifyStatusChanged() {
+  updateBadge();
+  const status = getStatusPayload();
   chrome.runtime.sendMessage({
-    action: 'countUpdated',
-    count: settings.cleanedCount
+    action: 'statusUpdated',
+    status
   }).catch(() => {
-    // Popup is not open - nothing to do
+    // No listeners available
   });
+}
+
+function getStatusPayload() {
+  return {
+    isEnabled: settings.isEnabled,
+    cleanedCount: settings.cleanedCount,
+    excludedDomains: settings.excludedDomains,
+    pauseUntil: settings.pauseUntil,
+    isPaused: isTemporarilyPaused()
+  };
+}
+
+function extractHostname(url) {
+  try {
+    return new URL(url).hostname;
+  } catch (e) {
+    return null;
+  }
+}
+
+function ensurePauseFreshness() {
+  if (settings.pauseUntil && Date.now() >= settings.pauseUntil) {
+    settings.pauseUntil = null;
+    chrome.storage.sync.set({ pauseUntil: null });
+  }
+}
+
+function isTemporarilyPaused() {
+  ensurePauseFreshness();
+  return Boolean(settings.pauseUntil && Date.now() < settings.pauseUntil);
+}
+
+function isDomainExcluded(url) {
+  const hostname = extractHostname(url);
+  return hostname ? settings.excludedDomains.includes(hostname) : false;
 }
 
 // Observe tab updates to trigger URL cleaning
@@ -138,8 +215,23 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     return;
   }
 
+  if (tabId === activeTabId && changeInfo.url) {
+    activeTabDomain = extractHostname(changeInfo.url);
+    updateBadge();
+  }
+
+  if (isTemporarilyPaused()) {
+    console.log('Clean URL: Temporarily paused');
+    updateBadge();
+    return;
+  }
+
   // Only process when the tab has a URL and it is changing
   if (changeInfo.url && tab.url) {
+    if (isDomainExcluded(changeInfo.url)) {
+      console.log('Clean URL: Domain excluded', extractHostname(changeInfo.url));
+      return;
+    }
     const cleanedURL = cleanURL(changeInfo.url);
 
     if (cleanedURL && cleanedURL !== changeInfo.url) {
@@ -154,6 +246,21 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
 chrome.webNavigation.onCommitted.addListener((details) => {
   // Only handle the main frame while enabled
   if (!settings.isEnabled || details.frameId !== 0) {
+    return;
+  }
+
+  if (details.tabId === activeTabId) {
+    activeTabDomain = extractHostname(details.url);
+    updateBadge();
+  }
+
+  if (isTemporarilyPaused()) {
+    console.log('Clean URL: Temporarily paused');
+    return;
+  }
+
+  if (isDomainExcluded(details.url)) {
+    console.log('Clean URL: Domain excluded', extractHostname(details.url));
     return;
   }
 
@@ -172,23 +279,60 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
   if (request.action === 'toggle') {
     settings.isEnabled = request.enabled;
-    chrome.storage.sync.set({ isEnabled: settings.isEnabled });
-    updateBadge();
+    settings.pauseUntil = null;
+    chrome.storage.sync.set({ isEnabled: settings.isEnabled, pauseUntil: null });
+    notifyStatusChanged();
     console.log('Clean URL: Toggled', settings.isEnabled);
     sendResponse({ success: true, isEnabled: settings.isEnabled });
 
   } else if (request.action === 'getStatus') {
-    sendResponse({
-      isEnabled: settings.isEnabled,
-      cleanedCount: settings.cleanedCount
-    });
+    sendResponse(getStatusPayload());
 
   } else if (request.action === 'resetCount') {
     settings.cleanedCount = 0;
     chrome.storage.sync.set({ cleanedCount: 0 });
-    updateBadge();
+    notifyStatusChanged();
     console.log('Clean URL: Reset count');
     sendResponse({ success: true });
+  } else if (request.action === 'pause') {
+    const durationMinutes = Number(request.minutes);
+    if (!Number.isFinite(durationMinutes) || durationMinutes <= 0) {
+      sendResponse({ success: false, error: 'Invalid duration' });
+      return true;
+    }
+    settings.pauseUntil = Date.now() + durationMinutes * 60 * 1000;
+    chrome.storage.sync.set({ pauseUntil: settings.pauseUntil });
+    notifyStatusChanged();
+    console.log('Clean URL: Paused until', new Date(settings.pauseUntil).toISOString());
+    sendResponse({ success: true, pauseUntil: settings.pauseUntil });
+  } else if (request.action === 'resume') {
+    settings.pauseUntil = null;
+    chrome.storage.sync.set({ pauseUntil: null });
+    notifyStatusChanged();
+    console.log('Clean URL: Pause cleared');
+    sendResponse({ success: true });
+  } else if (request.action === 'updateExcludedDomain') {
+    const domain = request.domain;
+    if (!domain) {
+      sendResponse({ success: false, error: 'Invalid domain' });
+      return true;
+    }
+    const shouldExclude = Boolean(request.exclude);
+    const existingIndex = settings.excludedDomains.indexOf(domain);
+    let changed = false;
+    if (shouldExclude && existingIndex === -1) {
+      settings.excludedDomains.push(domain);
+      changed = true;
+    } else if (!shouldExclude && existingIndex !== -1) {
+      settings.excludedDomains.splice(existingIndex, 1);
+      changed = true;
+    }
+    if (changed) {
+      chrome.storage.sync.set({ excludedDomains: settings.excludedDomains });
+      notifyStatusChanged();
+      console.log('Clean URL: Updated exclusions', settings.excludedDomains);
+    }
+    sendResponse({ success: true, excludedDomains: settings.excludedDomains.slice() });
   }
 
   return true; // Keep the channel open for async responses
@@ -197,16 +341,49 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // Sync settings updates from other extension contexts
 chrome.storage.onChanged.addListener((changes, namespace) => {
   if (namespace === 'sync') {
+    let shouldNotify = false;
     if (changes.isEnabled) {
       settings.isEnabled = changes.isEnabled.newValue;
       console.log('Clean URL: Settings synced - isEnabled:', settings.isEnabled);
       updateBadge();
+      shouldNotify = true;
     }
     if (changes.cleanedCount) {
       settings.cleanedCount = changes.cleanedCount.newValue;
       updateBadge();
+      shouldNotify = true;
+    }
+    if (changes.excludedDomains) {
+      settings.excludedDomains = Array.isArray(changes.excludedDomains.newValue)
+        ? changes.excludedDomains.newValue
+        : [];
+      updateBadge();
+      shouldNotify = true;
+    }
+    if (changes.pauseUntil) {
+      settings.pauseUntil = typeof changes.pauseUntil.newValue === 'number'
+        ? changes.pauseUntil.newValue
+        : null;
+      updateBadge();
+      shouldNotify = true;
+    }
+    if (shouldNotify) {
+      notifyStatusChanged();
     }
   }
+});
+
+chrome.tabs.onActivated.addListener(({ tabId }) => {
+  activeTabId = tabId;
+  chrome.tabs.get(tabId, (tab) => {
+    if (chrome.runtime.lastError) {
+      console.warn('Clean URL: Unable to get activated tab', chrome.runtime.lastError);
+      activeTabDomain = null;
+    } else {
+      activeTabDomain = extractHostname(tab.url);
+    }
+    updateBadge();
+  });
 });
 
 console.log('Clean URL: Background script loaded');

--- a/popup.html
+++ b/popup.html
@@ -129,11 +129,139 @@
     .button:hover {
       background: #1976D2;
     }
-    
+
     .button:active {
       transform: scale(0.98);
     }
-    
+
+    .button.secondary {
+      background: #6c757d;
+    }
+
+    .button.secondary:hover {
+      background: #545b62;
+    }
+
+    .button.tertiary {
+      background: #ff7043;
+    }
+
+    .button.tertiary:hover {
+      background: #f4511e;
+    }
+
+    .inline-button {
+      width: auto;
+      margin-top: 0;
+      padding: 8px 16px;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .section {
+      margin: 15px 0;
+      padding: 12px;
+      background: #f8f9fa;
+      border-radius: 8px;
+    }
+
+    .section-title {
+      font-weight: 600;
+      font-size: 14px;
+      color: #333;
+      margin-bottom: 10px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .pause-controls {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .pause-select {
+      flex: 1;
+      min-width: 140px;
+      padding: 8px;
+      border-radius: 6px;
+      border: 1px solid #d0d7de;
+      font-size: 13px;
+    }
+
+    .pause-info {
+      margin-top: 8px;
+      font-size: 12px;
+      color: #555;
+    }
+
+    .site-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .muted-label {
+      font-size: 12px;
+      color: #777;
+    }
+
+    .domain-label {
+      font-size: 13px;
+      font-weight: 500;
+      color: #333;
+      margin-top: 4px;
+      max-width: 180px;
+      word-break: break-word;
+    }
+
+    .excluded-list {
+      list-style: none;
+      padding: 0;
+      margin: 10px 0 0 0;
+      max-height: 140px;
+      overflow-y: auto;
+    }
+
+    .excluded-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      background: #ffffff;
+      border-radius: 6px;
+      padding: 6px 10px;
+      margin-bottom: 6px;
+      font-size: 12px;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    }
+
+    .excluded-list .empty {
+      justify-content: center;
+      color: #777;
+    }
+
+    .remove-button {
+      background: transparent;
+      border: none;
+      color: #F44336;
+      cursor: pointer;
+      font-size: 12px;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 6px;
+      border-radius: 4px;
+    }
+
+    .remove-button:hover {
+      background: rgba(244, 67, 54, 0.1);
+    }
+
     .supported {
       margin-top: 15px;
       padding: 12px;
@@ -185,6 +313,35 @@
       <input type="checkbox" id="toggleSwitch" checked>
       <span class="slider"></span>
     </label>
+  </div>
+
+  <div class="section">
+    <div class="section-title">⏱️ Pause cleaning</div>
+    <div class="pause-controls">
+      <select id="pauseSelect" class="pause-select">
+        <option value="10">10 minutes</option>
+        <option value="30">30 minutes</option>
+        <option value="60">1 hour</option>
+        <option value="1440">1 day</option>
+        <option value="10080">1 week</option>
+      </select>
+      <button class="button secondary inline-button" id="pauseBtn">⏸️ Pause</button>
+      <button class="button inline-button" id="resumeBtn">▶️ Resume</button>
+    </div>
+    <div class="pause-info" id="pauseInfo">Not paused</div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">🛡️ Site exclusions</div>
+    <div class="site-row">
+      <div>
+        <div class="muted-label">Current site</div>
+        <div class="domain-label" id="currentDomain">Loading…</div>
+      </div>
+      <button class="button tertiary inline-button" id="toggleSiteBtn">🚫 Exclude</button>
+    </div>
+    <div class="muted-label" style="margin-top: 12px;">Excluded sites</div>
+    <ul class="excluded-list" id="excludedList"></ul>
   </div>
 
   <button class="button" id="resetBtn">🔄 Reset counter</button>

--- a/popup.js
+++ b/popup.js
@@ -1,86 +1,338 @@
+const statusTextEl = document.getElementById('statusText');
+const toggleSwitch = document.getElementById('toggleSwitch');
+const cleanedCountEl = document.getElementById('cleanedCount');
+const pauseSelect = document.getElementById('pauseSelect');
+const pauseButton = document.getElementById('pauseBtn');
+const resumeButton = document.getElementById('resumeBtn');
+const pauseInfoEl = document.getElementById('pauseInfo');
+const toggleSiteButton = document.getElementById('toggleSiteBtn');
+const currentDomainEl = document.getElementById('currentDomain');
+const excludedListEl = document.getElementById('excludedList');
+const resetButton = document.getElementById('resetBtn');
+const refreshButton = document.getElementById('refreshBtn');
+
 let currentStatus = {
   isEnabled: true,
-  cleanedCount: 0
+  cleanedCount: 0,
+  excludedDomains: [],
+  pauseUntil: null,
+  isPaused: false
 };
 
-// Update popup UI elements to reflect the latest state
-function updateUI() {
-  document.getElementById('toggleSwitch').checked = currentStatus.isEnabled;
-  document.getElementById('cleanedCount').textContent = currentStatus.cleanedCount;
-  document.getElementById('statusText').textContent =
-    currentStatus.isEnabled ? '✅ Enabled' : '⏸️ Disabled';
-  document.getElementById('statusText').style.color =
-    currentStatus.isEnabled ? '#4CAF50' : '#F44336';
+let currentDomain = null;
+
+function applyStatusUpdate(status) {
+  if (!status) {
+    return;
+  }
+
+  const pauseUntil = typeof status.pauseUntil === 'number' ? status.pauseUntil : null;
+  currentStatus = {
+    ...currentStatus,
+    ...status,
+    pauseUntil,
+    excludedDomains: Array.isArray(status.excludedDomains)
+      ? status.excludedDomains
+      : currentStatus.excludedDomains,
+    isPaused: Boolean(pauseUntil && Date.now() < pauseUntil)
+  };
+
+  updateUI();
 }
 
-// Fetch the current status when the popup opens
+function updateUI() {
+  if (toggleSwitch) {
+    toggleSwitch.checked = currentStatus.isEnabled;
+  }
+
+  if (cleanedCountEl) {
+    cleanedCountEl.textContent = currentStatus.cleanedCount;
+  }
+
+  const domainExcluded = Boolean(
+    currentDomain && currentStatus.excludedDomains.includes(currentDomain)
+  );
+
+  if (statusTextEl) {
+    let text = '✅ Enabled';
+    let color = '#4CAF50';
+
+    if (!currentStatus.isEnabled) {
+      text = '⏸️ Disabled';
+      color = '#F44336';
+    } else if (currentStatus.isPaused) {
+      text = '⏳ Paused';
+      color = '#FF9800';
+    } else if (domainExcluded) {
+      text = '🚫 Excluded on this site';
+      color = '#FF7043';
+    }
+
+    statusTextEl.textContent = text;
+    statusTextEl.style.color = color;
+  }
+
+  if (pauseSelect) {
+    pauseSelect.disabled = !currentStatus.isEnabled;
+  }
+  if (pauseButton) {
+    pauseButton.disabled = !currentStatus.isEnabled;
+  }
+  if (resumeButton) {
+    resumeButton.disabled = !currentStatus.isPaused;
+  }
+
+  if (pauseInfoEl) {
+    pauseInfoEl.textContent = formatPauseInfo();
+  }
+
+  if (currentDomainEl) {
+    currentDomainEl.textContent = currentDomain || 'Unavailable';
+  }
+
+  if (toggleSiteButton) {
+    toggleSiteButton.disabled = !currentDomain || !currentStatus.isEnabled;
+    toggleSiteButton.textContent = domainExcluded ? '✅ Include' : '🚫 Exclude';
+  }
+
+  renderExcludedDomains();
+}
+
+function renderExcludedDomains() {
+  if (!excludedListEl) {
+    return;
+  }
+
+  excludedListEl.innerHTML = '';
+
+  if (!currentStatus.excludedDomains.length) {
+    const emptyItem = document.createElement('li');
+    emptyItem.className = 'empty';
+    emptyItem.textContent = 'No sites excluded yet.';
+    excludedListEl.appendChild(emptyItem);
+    return;
+  }
+
+  currentStatus.excludedDomains
+    .slice()
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((domain) => {
+      const item = document.createElement('li');
+      const label = document.createElement('span');
+      label.textContent = domain;
+      const removeBtn = document.createElement('button');
+      removeBtn.className = 'remove-button';
+      removeBtn.textContent = '✖ Remove';
+      removeBtn.addEventListener('click', () => {
+        updateDomainExclusion(domain, false);
+      });
+      item.appendChild(label);
+      item.appendChild(removeBtn);
+      excludedListEl.appendChild(item);
+    });
+}
+
+function formatPauseInfo() {
+  if (!currentStatus.isPaused || !currentStatus.pauseUntil) {
+    return 'Not paused';
+  }
+
+  const remainingMs = currentStatus.pauseUntil - Date.now();
+  if (remainingMs <= 0) {
+    return 'Not paused';
+  }
+
+  const endTime = new Date(currentStatus.pauseUntil);
+  const timeString = endTime.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return `Paused until ${timeString} (${humanizeDuration(remainingMs)} left)`;
+}
+
+function humanizeDuration(ms) {
+  const totalMinutes = Math.ceil(ms / 60000);
+  if (totalMinutes <= 1) {
+    return '<1m';
+  }
+
+  const days = Math.floor(totalMinutes / 1440);
+  const hours = Math.floor((totalMinutes % 1440) / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+  }
+  if (hours > 0) {
+    parts.push(`${hours}h`);
+  }
+  if (minutes > 0 && days === 0) {
+    parts.push(`${minutes}m`);
+  }
+
+  return parts.join(' ');
+}
+
+function refreshCurrentTab() {
+  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+    if (chrome.runtime.lastError) {
+      console.error('Error querying active tab:', chrome.runtime.lastError);
+      currentDomain = null;
+      updateUI();
+      return;
+    }
+    const [tab] = tabs;
+    currentDomain = tab ? extractHostname(tab.url) : null;
+    updateUI();
+  });
+}
+
+function extractHostname(url) {
+  try {
+    return new URL(url).hostname;
+  } catch (e) {
+    return null;
+  }
+}
+
+function updateDomainExclusion(domain, exclude) {
+  chrome.runtime.sendMessage(
+    {
+      action: 'updateExcludedDomain',
+      domain,
+      exclude
+    },
+    (response) => {
+      if (chrome.runtime.lastError) {
+        console.error('Error updating exclusions:', chrome.runtime.lastError);
+        return;
+      }
+      if (response?.success) {
+        currentStatus.excludedDomains = Array.isArray(response.excludedDomains)
+          ? response.excludedDomains
+          : currentStatus.excludedDomains;
+        currentStatus.isPaused = Boolean(
+          currentStatus.pauseUntil && Date.now() < currentStatus.pauseUntil
+        );
+        updateUI();
+      }
+    }
+  );
+}
+
 function loadStatus() {
   chrome.runtime.sendMessage({ action: 'getStatus' }, (response) => {
     if (chrome.runtime.lastError) {
       console.error('Error:', chrome.runtime.lastError);
       return;
     }
-    if (response) {
-      currentStatus = response;
-      updateUI();
-      console.log('Status loaded:', currentStatus);
-    }
+    applyStatusUpdate(response);
+    refreshCurrentTab();
   });
 }
 
-// Initialize the popup
 loadStatus();
+refreshCurrentTab();
 
-// Listen for updates from the background script
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === 'countUpdated') {
+chrome.runtime.onMessage.addListener((request) => {
+  if (request.action === 'statusUpdated') {
+    applyStatusUpdate(request.status);
+    refreshCurrentTab();
+  } else if (request.action === 'countUpdated') {
     currentStatus.cleanedCount = request.count;
     updateUI();
   }
 });
 
-// Handle toggle switch interaction
-const toggleSwitch = document.getElementById('toggleSwitch');
 if (toggleSwitch) {
-  toggleSwitch.addEventListener('change', (e) => {
-    const enabled = e.target.checked;
+  toggleSwitch.addEventListener('change', (event) => {
+    const enabled = event.target.checked;
+    chrome.runtime.sendMessage(
+      {
+        action: 'toggle',
+        enabled
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          console.error('Toggle error:', chrome.runtime.lastError);
+          event.target.checked = !enabled;
+          return;
+        }
+        if (response?.success) {
+          currentStatus.isEnabled = enabled;
+          currentStatus.pauseUntil = null;
+          currentStatus.isPaused = false;
+          updateUI();
+        }
+      }
+    );
+  });
+}
 
-    chrome.runtime.sendMessage({
-      action: 'toggle',
-      enabled: enabled
-    }, (response) => {
+if (pauseButton) {
+  pauseButton.addEventListener('click', () => {
+    if (!pauseSelect) {
+      return;
+    }
+    const minutes = Number(pauseSelect.value);
+    if (!Number.isFinite(minutes) || minutes <= 0) {
+      return;
+    }
+    chrome.runtime.sendMessage(
+      {
+        action: 'pause',
+        minutes
+      },
+      (response) => {
+        if (chrome.runtime.lastError) {
+          console.error('Pause error:', chrome.runtime.lastError);
+          return;
+        }
+        if (response?.success) {
+          currentStatus.pauseUntil = response.pauseUntil;
+          currentStatus.isPaused = true;
+          updateUI();
+        }
+      }
+    );
+  });
+}
+
+if (resumeButton) {
+  resumeButton.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ action: 'resume' }, (response) => {
       if (chrome.runtime.lastError) {
-        console.error('Toggle error:', chrome.runtime.lastError);
-        // Revert the switch to its previous state on error
-        e.target.checked = !enabled;
+        console.error('Resume error:', chrome.runtime.lastError);
         return;
       }
-      if (response && response.success) {
-        currentStatus.isEnabled = enabled;
+      if (response?.success) {
+        currentStatus.pauseUntil = null;
+        currentStatus.isPaused = false;
         updateUI();
-        console.log('Toggled:', enabled);
       }
     });
   });
 }
 
-// Reset button to clear the cleaned URL counter
-const resetButton = document.getElementById('resetBtn');
+if (toggleSiteButton) {
+  toggleSiteButton.addEventListener('click', () => {
+    if (!currentDomain) {
+      return;
+    }
+    const isExcluded = currentStatus.excludedDomains.includes(currentDomain);
+    updateDomainExclusion(currentDomain, !isExcluded);
+  });
+}
+
 if (resetButton) {
   resetButton.addEventListener('click', () => {
     chrome.runtime.sendMessage({ action: 'resetCount' }, (response) => {
-      if (response && response.success) {
+      if (response?.success) {
         currentStatus.cleanedCount = 0;
         updateUI();
-        console.log('Count reset');
       }
     });
   });
 }
 
-// Optional refresh button to fetch the latest status manually
-const refreshButton = document.getElementById('refreshBtn');
 refreshButton?.addEventListener('click', () => {
   loadStatus();
 });
-


### PR DESCRIPTION
## Summary
- add popup controls to pause cleaning for preset durations and resume when ready
- provide per-site exclusion management backed by synced storage and badge feedback
- teach the background worker to honor pauses/exclusions and broadcast state updates to the popup

## Testing
- Not run (manual verification required)


------
https://chatgpt.com/codex/tasks/task_e_68de0f34975c832889fc0f28871a5a50